### PR TITLE
docs: apply Sphinx best practices to CHANGES.rst

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,7 @@ New features
 ''''''''''''
 
 - Added conventional commits configuration (``.cz.toml``), pre-commit hooks, CI workflows, and documentation. See `Issue 27 <https://github.com/mergecal/icalendar-anonymizer/issues/27>`_.
+- Applied Sphinx best practices to ``CHANGES.rst`` including proper RST roles, subheadings, and past tense verbs. See `Issue 31 <https://github.com/mergecal/icalendar-anonymizer/issues/31>`_.
 
 Bug fixes
 '''''''''


### PR DESCRIPTION
Applied @stevepiercy's suggestions from #26.

- Use Sphinx roles with examples (`:py:func:`, `:file:`, inline literals)
- Past tense verbs for changelog entries ("Added", "Fixed")
- RST subheadings for categories
- "icalendar-anonymizer uses" instead of "We use"
- Issue reference guidance with code block

Closes #31