### PR TITLE
docs: add missing changelog entries for #16 and #14

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,8 @@ New features
 
 - Added conventional commits configuration (``.cz.toml``), pre-commit hooks, CI workflows, and documentation. See `Issue 27 <https://github.com/mergecal/icalendar-anonymizer/issues/27>`_.
 - Applied Sphinx best practices to ``CHANGES.rst`` including proper RST roles, subheadings, and past tense verbs. See `Issue 31 <https://github.com/mergecal/icalendar-anonymizer/issues/31>`_.
+- Added project configuration files (``.gitignore``, ``.editorconfig``, ``.python-version``, ``requirements-dev.txt``). See `Issue 16 <https://github.com/mergecal/icalendar-anonymizer/issues/16>`_.
+- Added AGPL-3.0-or-later license. See `Issue 14 <https://github.com/mergecal/icalendar-anonymizer/issues/14>`_.
 
 Bug fixes
 '''''''''


### PR DESCRIPTION
Added missing CHANGES.rst entries for #33 and #34.

PRs #33 and #34 had 'DO NOT MERGE' comments to wait for #32, but Nicco merged them anyway. This adds the missing changelog entries.