### PR TITLE
feat(web): add Docker setup for self-hosting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,7 @@ Change log
 New features
 ''''''''''''
 
+- Added Docker setup for self-hosting. Multi-stage :file:`Dockerfile` with Python 3.13-slim, non-root user (UID 1000), and gunicorn with uvicorn workers. Health check endpoint ``GET /health`` returns service status, version, and feature flags. :file:`docker-compose.yml` with environment variables for host, port, workers, and file size limit. Documentation at :file:`docs/usage/self-hosting.rst`. See `Issue 8 <https://github.com/mergecal/icalendar-anonymizer/issues/8>`_.
 - Added frontend interface with file upload, paste, and URL fetch capabilities. Implemented drag and drop file upload with visual feedback. Added progressive enhancement for no-JavaScript environments. Provided WCAG AA compliant accessibility features (keyboard navigation, screen readers). Included mobile-responsive design for all device sizes. Zero external dependencies (vanilla HTML/CSS/JS). See `Issue 5 <https://github.com/mergecal/icalendar-anonymizer/issues/5>`_.
 - Added FastAPI web service with three endpoints: ``POST /anonymize`` (JSON), ``POST /upload`` (file), ``GET /fetch`` (URL). SSRF protection blocks private IPs, localhost, and invalid schemes. 10s timeout, 10MB limit. Install: ``pip install icalendar-anonymizer[web]``. See `Issue 4 <https://github.com/mergecal/icalendar-anonymizer/issues/4>`_.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,26 @@
 
 # syntax=docker/dockerfile:1
 
+# Build stage
+FROM python:3.13-slim AS builder
+
+WORKDIR /build
+
+# Install build dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy project files
+COPY pyproject.toml README.md ./
+COPY .git/ ./.git/
+COPY src/ ./src/
+
+# Build wheel
+RUN pip install --no-cache-dir build && \
+    python -m build --wheel
+
+# Runtime stage
 FROM python:3.13-slim
 
 LABEL org.opencontainers.image.title="icalendar-anonymizer"
@@ -11,23 +31,39 @@ LABEL org.opencontainers.image.url="https://github.com/mergecal/icalendar-anonym
 LABEL org.opencontainers.image.source="https://github.com/mergecal/icalendar-anonymizer"
 LABEL org.opencontainers.image.licenses="AGPL-3.0-or-later"
 
-# Install git for version detection
-RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+# Create non-root user
+RUN useradd -m -u 1000 -s /bin/bash appuser
 
 WORKDIR /app
-ENV PYTHONUNBUFFERED=true
 
-# Copy project files including .git for version detection
-COPY pyproject.toml README.md ./
-COPY .git/ ./.git/
-COPY src/ ./src/
+# Copy wheel from builder
+COPY --from=builder /build/dist/*.whl /tmp/
 
-# Install the package with all dependencies
-RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -e ".[all]"
+# Install the package with web dependencies, gunicorn, uvicorn and performance extras
+RUN pip install --no-cache-dir "$(ls /tmp/*.whl)[web]" \
+    gunicorn httptools uvloop && \
+    rm -rf /tmp/*.whl
 
-# Expose port for web service
+# Switch to non-root user
+USER appuser
+
+# Environment variables with defaults
+ENV HOST=0.0.0.0 \
+    PORT=8000 \
+    WORKERS=4 \
+    PYTHONUNBUFFERED=1
+
+# Expose port
 EXPOSE 8000
 
-# Run the web service
-CMD ["uvicorn", "icalendar_anonymizer.webapp.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"
+
+# Run with gunicorn
+CMD gunicorn icalendar_anonymizer.webapp.main:app \
+    --bind ${HOST}:${PORT} \
+    --workers ${WORKERS} \
+    --worker-class uvicorn.workers.UvicornWorker \
+    --access-logfile - \
+    --error-logfile -

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 icalendar-anonymizer contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+services:
+  icalendar-anonymizer:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      # Server configuration
+      - HOST=0.0.0.0
+      - PORT=8000
+      - WORKERS=4
+
+      # File size limit (in bytes, default 10MB)
+      - MAX_FILE_SIZE=10485760
+
+    restart: unless-stopped
+
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 5s

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,7 +32,13 @@ Strip personal data from iCalendar files while preserving technical properties f
         :link: usage/web-service
         :link-type: doc
 
-        REST API endpoints and self-hosting
+        REST API endpoints for anonymization
+
+    .. grid-item-card:: 🐳 Self-Hosting
+        :link: usage/self-hosting
+        :link-type: doc
+
+        Run locally with Docker for data privacy
 
     .. grid-item-card:: 📚 API Reference
         :link: api/index
@@ -98,6 +104,7 @@ Documentation
     usage/python-api
     usage/cli
     usage/web-service
+    usage/self-hosting
     api/index
 
 .. toctree::

--- a/docs/usage/self-hosting.rst
+++ b/docs/usage/self-hosting.rst
@@ -1,0 +1,282 @@
+..
+   SPDX-FileCopyrightText: 2025 icalendar-anonymizer contributors
+   SPDX-License-Identifier: AGPL-3.0-or-later
+
+============
+Self-Hosting
+============
+
+Run icalendar-anonymizer locally with Docker for complete data privacy.
+
+Why Self-Host?
+==============
+
+Some people won't trust a web service with their calendar data. They need to run this locally. Docker makes that easy.
+
+If your company policy says no external services, you can pull the Docker image, run it locally, and use it via localhost:8000. Your data never leaves your machine.
+
+Quick Start
+===========
+
+Prerequisites
+-------------
+
+- Docker installed
+- Docker Compose installed (included with Docker Desktop)
+
+Basic Setup
+-----------
+
+.. code-block:: bash
+
+   # Clone the repository
+   git clone https://github.com/mergecal/icalendar-anonymizer.git
+   cd icalendar-anonymizer
+
+   # Start the service
+   docker-compose up -d
+
+   # View logs
+   docker-compose logs -f
+
+   # Stop the service
+   docker-compose down
+
+The service will be available at http://localhost:8000
+
+Configuration
+=============
+
+Environment Variables
+---------------------
+
+Configure the service by editing ``docker-compose.yml`` or setting environment variables:
+
+Server Configuration
+~~~~~~~~~~~~~~~~~~~~
+
+``HOST``
+   Network interface to bind to (default: ``0.0.0.0``)
+
+``PORT``
+   Port number to listen on (default: ``8000``)
+
+``WORKERS``
+   Number of Gunicorn worker processes (default: ``4``)
+
+File Handling
+~~~~~~~~~~~~~
+
+``MAX_FILE_SIZE``
+   Maximum upload size in bytes (default: ``10485760`` = 10MB)
+
+Example docker-compose.yml
+--------------------------
+
+.. code-block:: yaml
+
+   services:
+     icalendar-anonymizer:
+       build: .
+       ports:
+         - "8000:8000"
+       environment:
+         - HOST=0.0.0.0
+         - PORT=8000
+         - WORKERS=4
+         - MAX_FILE_SIZE=10485760
+       restart: unless-stopped
+
+Docker Commands
+===============
+
+Build the Image
+---------------
+
+.. code-block:: bash
+
+   docker-compose build
+
+Start the Service
+-----------------
+
+.. code-block:: bash
+
+   # Start in background
+   docker-compose up -d
+
+   # Start with logs visible
+   docker-compose up
+
+View Logs
+---------
+
+.. code-block:: bash
+
+   # Follow logs
+   docker-compose logs -f
+
+   # View last 100 lines
+   docker-compose logs --tail=100
+
+Stop the Service
+----------------
+
+.. code-block:: bash
+
+   docker-compose down
+
+Restart the Service
+-------------------
+
+.. code-block:: bash
+
+   docker-compose restart
+
+Update to Latest Version
+------------------------
+
+.. code-block:: bash
+
+   git pull
+   docker-compose build
+   docker-compose up -d
+
+Health Check
+============
+
+The service includes a health check endpoint at ``/health`` that returns:
+
+.. code-block:: json
+
+   {
+     "status": "healthy",
+     "version": "0.1.0",
+     "r2_enabled": false
+   }
+
+Docker uses this endpoint to monitor service health. You can also check it manually:
+
+.. code-block:: bash
+
+   curl http://localhost:8000/health
+
+Security Considerations
+=======================
+
+Non-Root User
+-------------
+
+The Docker container runs as a non-root user (UID 1000) for security.
+
+Network Isolation
+-----------------
+
+The service only exposes port 8000. No other services or ports are accessible.
+
+SSRF Protection
+---------------
+
+URL fetching includes SSRF protection that blocks:
+
+- Private IP ranges (10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12)
+- Loopback addresses (127.0.0.1, localhost)
+- Link-local addresses (169.254.0.0/16)
+
+Known limitation: DNS rebinding attacks may bypass these checks. See Issue #70 for details.
+
+File Size Limits
+----------------
+
+Default 10MB limit prevents DoS attacks via large file uploads. Adjust via ``MAX_FILE_SIZE`` if needed.
+
+Production Deployment
+=====================
+
+For production environments:
+
+1. **Use HTTPS**: Put the service behind a reverse proxy (nginx, Caddy, Traefik) with TLS
+2. **Tighten CORS**: Edit ``main.py`` to allow only specific origins instead of ``*``
+3. **Add authentication**: See Issue #79 for planned authentication support
+4. **Monitor logs**: Set up log aggregation and monitoring
+5. **Regular updates**: Subscribe to security advisories and update promptly
+
+Reverse Proxy Example (nginx)
+-----------------------------
+
+.. code-block:: nginx
+
+   server {
+       listen 443 ssl http2;
+       server_name calendar.example.com;
+
+       ssl_certificate /path/to/cert.pem;
+       ssl_certificate_key /path/to/key.pem;
+
+       location / {
+           proxy_pass http://localhost:8000;
+           proxy_set_header Host $host;
+           proxy_set_header X-Real-IP $remote_addr;
+           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+           proxy_set_header X-Forwarded-Proto $scheme;
+       }
+   }
+
+Troubleshooting
+===============
+
+Service Won't Start
+-------------------
+
+Check logs:
+
+.. code-block:: bash
+
+   docker-compose logs
+
+Common issues:
+
+- Port 8000 already in use: Change ``PORT`` in docker-compose.yml
+- Permission denied: Ensure Docker daemon is running
+
+Health Check Failing
+--------------------
+
+Check if the service is responding:
+
+.. code-block:: bash
+
+   docker-compose exec icalendar-anonymizer curl http://localhost:8000/health
+
+If no response, check worker logs for errors.
+
+Build Fails
+-----------
+
+Ensure you have the .git directory (needed for version detection):
+
+.. code-block:: bash
+
+   ls -la .git
+
+If missing, clone the repository instead of downloading a ZIP archive.
+
+Image Too Large
+---------------
+
+The image is built with multi-stage builds to stay under 200MB. If larger:
+
+1. Clean Docker build cache: ``docker system prune``
+2. Rebuild: ``docker-compose build --no-cache``
+
+Performance Issues
+------------------
+
+Adjust worker count based on CPU cores:
+
+.. code-block:: yaml
+
+   environment:
+     - WORKERS=8  # Increase for more cores
+
+Recommended: (CPU cores * 2) + 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ cli = ["click>=8.3.1"]
 
 web = [
     "fastapi>=0.125.0",
-    "uvicorn[standard]>=0.38.0",
+    "uvicorn>=0.38.0",
     "python-multipart>=0.0.18",
     "httpx>=0.28.0",
 ]

--- a/src/icalendar_anonymizer/tests/web/test_health.py
+++ b/src/icalendar_anonymizer/tests/web/test_health.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2025 icalendar-anonymizer contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for health check endpoint."""
+
+from fastapi.testclient import TestClient
+
+from icalendar_anonymizer.version import version
+from icalendar_anonymizer.webapp.main import app
+
+client = TestClient(app)
+
+
+class TestHealthEndpoint:
+    """Tests for /health endpoint."""
+
+    def test_health_returns_200(self):
+        """Test health endpoint returns 200 OK."""
+        response = client.get("/health")
+        assert response.status_code == 200
+
+    def test_health_returns_json(self):
+        """Test health endpoint returns JSON."""
+        response = client.get("/health")
+        assert response.headers["content-type"] == "application/json"
+
+    def test_health_response_structure(self):
+        """Test health endpoint response has correct structure."""
+        response = client.get("/health")
+        data = response.json()
+
+        assert "status" in data
+        assert "version" in data
+        assert "r2_enabled" in data
+
+    def test_health_status_is_healthy(self):
+        """Test health endpoint reports healthy status."""
+        response = client.get("/health")
+        data = response.json()
+
+        assert data["status"] == "healthy"
+
+    def test_health_version_matches_package(self):
+        """Test health endpoint version matches package version."""
+        response = client.get("/health")
+        data = response.json()
+
+        assert data["version"] == version
+
+    def test_health_r2_disabled_by_default(self):
+        """Test R2 is disabled by default."""
+        response = client.get("/health")
+        data = response.json()
+
+        assert data["r2_enabled"] is False

--- a/src/icalendar_anonymizer/webapp/main.py
+++ b/src/icalendar_anonymizer/webapp/main.py
@@ -8,6 +8,7 @@ file upload, and URL fetching with SSRF protection.
 """
 
 import ipaddress
+import os
 from pathlib import Path
 from typing import Annotated
 from urllib.parse import urlparse
@@ -21,11 +22,17 @@ from icalendar import Calendar
 from pydantic import BaseModel
 
 from icalendar_anonymizer import anonymize
+from icalendar_anonymizer.version import version
 
-# Constants
-MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
+# Constants (configurable via environment variables)
+try:
+    MAX_FILE_SIZE = int(os.getenv("MAX_FILE_SIZE") or 10 * 1024 * 1024)  # Default 10MB
+except ValueError as e:
+    raise ValueError(
+        f"MAX_FILE_SIZE must be a valid integer, got: {os.getenv('MAX_FILE_SIZE')!r}"
+    ) from e
 FETCH_TIMEOUT = 10.0  # seconds
-MAX_RESPONSE_SIZE = 10 * 1024 * 1024  # 10MB
+MAX_RESPONSE_SIZE = MAX_FILE_SIZE  # Match file size limit
 
 # Private IP ranges to block for SSRF protection
 PRIVATE_IP_RANGES = [
@@ -69,6 +76,28 @@ async def root() -> FileResponse:
         FileResponse: The index.html file
     """
     return FileResponse(STATIC_DIR / "index.html")
+
+
+class HealthResponse(BaseModel):
+    """Response model for /health endpoint."""
+
+    status: str
+    version: str
+    r2_enabled: bool
+
+
+@app.get("/health")
+async def health() -> HealthResponse:
+    """Health check endpoint for Docker and monitoring.
+
+    Returns:
+        HealthResponse: Service health status, version, and feature flags
+    """
+    return HealthResponse(
+        status="healthy",
+        version=version,
+        r2_enabled=False,  # R2 support not yet implemented
+    )
 
 
 class AnonymizeRequest(BaseModel):


### PR DESCRIPTION
Closes #8

Multi-stage Dockerfile with Python 3.13-slim, non-root user, gunicorn + uvicorn workers. Health check at GET /health. docker-compose.yml with environment variables. Self-hosting docs at docs/usage/self-hosting.rst.