### PR TITLE
fix: remove invalid wildcard route from wrangler.jsonc

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -15,13 +15,5 @@
   // Static assets configuration
   "assets": {
     "directory": "./src/icalendar_anonymizer/webapp/static"
-  },
-
-  // Custom domain routing
-  "routes": [
-    {
-      "pattern": "icalendar-anonymizer.com/*",
-      "custom_domain": true
-    }
-  ]
+  }
 }


### PR DESCRIPTION
Removes invalid wildcard route configuration that caused deployment failure. Custom domains should be configured in Cloudflare Dashboard instead.