### PR TITLE
fix: run build.sh after pywrangler sync

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Install workers-py (pywrangler)
         run: uv tool install workers-py
 
+      - name: Sync dependencies with pywrangler
+        run: uvx --from workers-py pywrangler sync
+
       - name: Build package for Workers
         run: bash build.sh
 
@@ -43,7 +46,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          uvx --from workers-py pywrangler deploy
+          uvx --from workers-py wrangler deploy
 
       - name: Deployment summary
         run: |


### PR DESCRIPTION
Fixes deployment by ensuring build.sh runs after pywrangler sync, not before.