### PR TITLE
fix: use JSON array form for Dockerfile CMD

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,26 @@ Change log
 ..
 .. - Start with a past tense verb, such as "Added", "Fixed", "Removed", "Updated", and other verbs.
 
+0.1.4 (unreleased)
+------------------
+
+.. _v0.1.4-new-features:
+
+New features
+''''''''''''
+
+.. _v0.1.4-minor-changes:
+
+Minor changes
+'''''''''''''
+
+.. _v0.1.4-bug-fixes:
+
+Bug fixes
+'''''''''
+
+- Fixed :file:`Dockerfile` ``CMD`` to use JSON array form with ``sh -c`` wrapper, resolving the ``JSONArgsRecommended`` lint warning while preserving shell variable expansion for ``HOST``, ``PORT``, and ``WORKERS``.
+
 0.1.3 (2026-04-02)
 ------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,9 +61,4 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"
 
 # Run with gunicorn
-CMD gunicorn icalendar_anonymizer.webapp.main:app \
-    --bind ${HOST}:${PORT} \
-    --workers ${WORKERS} \
-    --worker-class uvicorn.workers.UvicornWorker \
-    --access-logfile - \
-    --error-logfile -
+CMD ["sh", "-c", "gunicorn icalendar_anonymizer.webapp.main:app --bind ${HOST}:${PORT} --workers ${WORKERS} --worker-class uvicorn.workers.UvicornWorker --access-logfile - --error-logfile -"]


### PR DESCRIPTION
Fixes JSONArgsRecommended lint warning. Uses `sh -c` wrapper to preserve shell variable expansion for `${HOST}`, `${PORT}`, `${WORKERS}`.