### PR TITLE
fix: remove '(30-day expiry)' from shareable link labels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,8 @@ New features
 Minor changes
 '''''''''''''
 
+- Removed "(30-day expiry)" from shareable-link checkbox labels. See `Issue 113 <https://github.com/pycalendar/icalendar-anonymizer/issues/113>`_.
+
 .. _v0.1.4-bug-fixes:
 
 Bug fixes

--- a/src/icalendar_anonymizer/webapp/static/index.html
+++ b/src/icalendar_anonymizer/webapp/static/index.html
@@ -163,7 +163,7 @@
                 </details>
                 <label class="share-checkbox">
                     <input type="checkbox" id="upload-share" aria-label="Generate shareable link">
-                    Generate shareable link (30-day expiry)
+                    Generate shareable link
                 </label>
                 <button type="submit" class="btn">Anonymize</button>
             </form>
@@ -275,7 +275,7 @@
                 </details>
                 <label class="share-checkbox">
                     <input type="checkbox" id="paste-share" aria-label="Generate shareable link">
-                    Generate shareable link (30-day expiry)
+                    Generate shareable link
                 </label>
                 <button type="submit" class="btn">Anonymize</button>
             </form>
@@ -386,7 +386,7 @@
                 </details>
                 <label class="share-checkbox">
                     <input type="checkbox" id="fetch-share" aria-label="Generate shareable link">
-                    Generate shareable link (30-day expiry)
+                    Generate shareable link
                 </label>
                 <div class="share-options" id="fetch-share-options" hidden>
                     <label class="share-option" for="fetch-share-fernet">


### PR DESCRIPTION
Fixes #113.

Removes redundant '(30-day expiry)' from the three checkbox labels. Success message and radio option description keep the 30-day info for context.