### PR TITLE
fix: sync per-field options across Upload, Paste, and Fetch URL tabs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,7 @@ Minor changes
 '''''''''''''
 
 - Removed "(30-day expiry)" from shareable-link checkbox labels. See `Issue 113 <https://github.com/pycalendar/icalendar-anonymizer/issues/113>`_.
+- Synced per-field anonymization options across Upload, Paste, and Fetch URL tabs. See `Issue 115 <https://github.com/pycalendar/icalendar-anonymizer/issues/115>`_.
 
 .. _v0.1.4-bug-fixes:
 

--- a/src/icalendar_anonymizer/webapp/static/app.js
+++ b/src/icalendar_anonymizer/webapp/static/app.js
@@ -560,6 +560,24 @@ async function checkShareableLinks() {
     }
 }
 
+// Mirror field-config select changes to the same field on other tabs
+function initFieldSync() {
+    const sections = ['upload', 'paste', 'fetch'];
+    const selects = document.querySelectorAll('.field-config-grid select');
+
+    for (const select of selects) {
+        select.addEventListener('change', () => {
+            const [section, ...rest] = select.id.split('-');
+            const field = rest.join('-');
+            for (const other of sections) {
+                if (other === section) continue;
+                const peer = document.getElementById(`${other}-${field}`);
+                if (peer) peer.value = select.value;
+            }
+        });
+    }
+}
+
 // Toggle share options visibility when checkbox changes
 function initShareOptionsToggle() {
     const fetchShareCheckbox = document.getElementById('fetch-share');
@@ -578,6 +596,7 @@ document.addEventListener('DOMContentLoaded', () => {
     updateCopyrightYear();
     checkShareableLinks();
     initShareOptionsToggle();
+    initFieldSync();
     document.getElementById('upload-form').addEventListener('submit', handleUpload);
     document.getElementById('paste-form').addEventListener('submit', handlePaste);
     document.getElementById('fetch-form').addEventListener('submit', handleFetch);


### PR DESCRIPTION
Fixes #115.

Selecting a mode on one tab now mirrors to the same field on the other two tabs, so users don't lose configuration when switching input methods.