### PR TITLE
feat: persist per-field anonymization options across page loads

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,8 @@ Change log
 New features
 ''''''''''''
 
+- Persisted per-field anonymization options across page loads via ``localStorage``. See `Issue 116 <https://github.com/pycalendar/icalendar-anonymizer/issues/116>`_.
+
 .. _v0.1.4-minor-changes:
 
 Minor changes

--- a/src/icalendar_anonymizer/webapp/static/app.js
+++ b/src/icalendar_anonymizer/webapp/static/app.js
@@ -578,6 +578,37 @@ function initFieldSync() {
     }
 }
 
+// Persist field-config select values to localStorage so options survive page reloads
+function initFieldPersistence() {
+    const STORAGE_KEY = 'icalendar-anonymizer:field-modes';
+    const fieldOf = (id) => id.split('-').slice(1).join('-');
+
+    try {
+        const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+        for (const select of document.querySelectorAll('.field-config-grid select')) {
+            const saved = stored[fieldOf(select.id)];
+            if (saved && [...select.options].some(o => o.value === saved)) {
+                select.value = saved;
+            }
+        }
+    } catch {
+        // Corrupt JSON or localStorage unavailable — fall back to HTML defaults
+    }
+
+    document.addEventListener('change', (e) => {
+        if (!e.target.matches('.field-config-grid select')) return;
+        try {
+            const snapshot = {};
+            for (const s of document.querySelectorAll('#upload-panel .field-config-grid select')) {
+                snapshot[fieldOf(s.id)] = s.value;
+            }
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot));
+        } catch {
+            // localStorage unavailable (private mode, quota) — silently ignore
+        }
+    });
+}
+
 // Toggle share options visibility when checkbox changes
 function initShareOptionsToggle() {
     const fetchShareCheckbox = document.getElementById('fetch-share');
@@ -596,6 +627,7 @@ document.addEventListener('DOMContentLoaded', () => {
     updateCopyrightYear();
     checkShareableLinks();
     initShareOptionsToggle();
+    initFieldPersistence();
     initFieldSync();
     document.getElementById('upload-form').addEventListener('submit', handleUpload);
     document.getElementById('paste-form').addEventListener('submit', handlePaste);

--- a/src/icalendar_anonymizer/webapp/static/app.js
+++ b/src/icalendar_anonymizer/webapp/static/app.js
@@ -596,10 +596,11 @@ function initFieldPersistence() {
     }
 
     document.addEventListener('change', (e) => {
-        if (!e.target.matches('.field-config-grid select')) return;
+        const grid = e.target.closest('.field-config-grid');
+        if (!grid) return;
         try {
             const snapshot = {};
-            for (const s of document.querySelectorAll('#upload-panel .field-config-grid select')) {
+            for (const s of grid.querySelectorAll('select')) {
                 snapshot[fieldOf(s.id)] = s.value;
             }
             localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot));


### PR DESCRIPTION
Fixes #116.

Saves Advanced Options selections to localStorage on change, restores on page load. Survives browser restarts; resets only if the user clears site data.