### PR TITLE
fix: change web UI default field modes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,7 @@ Minor changes
 
 - Removed "(30-day expiry)" from shareable-link checkbox labels. See `Issue 113 <https://github.com/pycalendar/icalendar-anonymizer/issues/113>`_.
 - Synced per-field anonymization options across Upload, Paste, and Fetch URL tabs. See `Issue 115 <https://github.com/pycalendar/icalendar-anonymizer/issues/115>`_.
+- Changed web UI default field modes: SUMMARY keeps original, other text/address fields are removed, UID remains randomized. See `Issue 117 <https://github.com/pycalendar/icalendar-anonymizer/issues/117>`_.
 
 .. _v0.1.4-bug-fixes:
 

--- a/src/icalendar_anonymizer/webapp/static/index.html
+++ b/src/icalendar_anonymizer/webapp/static/index.html
@@ -73,8 +73,8 @@
                         <div class="field-option">
                             <label for="upload-summary">Summary</label>
                             <select id="upload-summary" name="summary">
-                                <option value="randomize" selected>Randomize (default)</option>
-                                <option value="keep">Keep original</option>
+                                <option value="randomize">Randomize</option>
+                                <option value="keep" selected>Keep original (default)</option>
                                 <option value="remove">Remove</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
@@ -82,72 +82,72 @@
                         <div class="field-option">
                             <label for="upload-description">Description</label>
                             <select id="upload-description" name="description">
-                                <option value="randomize" selected>Randomize (default)</option>
+                                <option value="randomize">Randomize</option>
                                 <option value="keep">Keep original</option>
-                                <option value="remove">Remove</option>
+                                <option value="remove" selected>Remove (default)</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
                         </div>
                         <div class="field-option">
                             <label for="upload-location">Location</label>
                             <select id="upload-location" name="location">
-                                <option value="randomize" selected>Randomize (default)</option>
+                                <option value="randomize">Randomize</option>
                                 <option value="keep">Keep original</option>
-                                <option value="remove">Remove</option>
+                                <option value="remove" selected>Remove (default)</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
                         </div>
                         <div class="field-option">
                             <label for="upload-comment">Comment</label>
                             <select id="upload-comment" name="comment">
-                                <option value="randomize" selected>Randomize (default)</option>
+                                <option value="randomize">Randomize</option>
                                 <option value="keep">Keep original</option>
-                                <option value="remove">Remove</option>
+                                <option value="remove" selected>Remove (default)</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
                         </div>
                         <div class="field-option">
                             <label for="upload-contact">Contact</label>
                             <select id="upload-contact" name="contact">
-                                <option value="randomize" selected>Randomize (default)</option>
+                                <option value="randomize">Randomize</option>
                                 <option value="keep">Keep original</option>
-                                <option value="remove">Remove</option>
+                                <option value="remove" selected>Remove (default)</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
                         </div>
                         <div class="field-option">
                             <label for="upload-resources">Resources</label>
                             <select id="upload-resources" name="resources">
-                                <option value="randomize" selected>Randomize (default)</option>
+                                <option value="randomize">Randomize</option>
                                 <option value="keep">Keep original</option>
-                                <option value="remove">Remove</option>
+                                <option value="remove" selected>Remove (default)</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
                         </div>
                         <div class="field-option">
                             <label for="upload-categories">Categories</label>
                             <select id="upload-categories" name="categories">
-                                <option value="randomize" selected>Randomize (default)</option>
+                                <option value="randomize">Randomize</option>
                                 <option value="keep">Keep original</option>
-                                <option value="remove">Remove</option>
+                                <option value="remove" selected>Remove (default)</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
                         </div>
                         <div class="field-option">
                             <label for="upload-attendee">Attendee</label>
                             <select id="upload-attendee" name="attendee">
-                                <option value="randomize" selected>Randomize (default)</option>
+                                <option value="randomize">Randomize</option>
                                 <option value="keep">Keep original</option>
-                                <option value="remove">Remove</option>
+                                <option value="remove" selected>Remove (default)</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
                         </div>
                         <div class="field-option">
                             <label for="upload-organizer">Organizer</label>
                             <select id="upload-organizer" name="organizer">
-                                <option value="randomize" selected>Randomize (default)</option>
+                                <option value="randomize">Randomize</option>
                                 <option value="keep">Keep original</option>
-                                <option value="remove">Remove</option>
+                                <option value="remove" selected>Remove (default)</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
                         </div>
@@ -185,8 +185,8 @@
                         <div class="field-option">
                             <label for="paste-summary">Summary</label>
                             <select id="paste-summary" name="summary">
-                                <option value="randomize" selected>Randomize (default)</option>
-                                <option value="keep">Keep original</option>
+                                <option value="randomize">Randomize</option>
+                                <option value="keep" selected>Keep original (default)</option>
                                 <option value="remove">Remove</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
@@ -194,72 +194,72 @@
                         <div class="field-option">
                             <label for="paste-description">Description</label>
                             <select id="paste-description" name="description">
-                                <option value="randomize" selected>Randomize (default)</option>
+                                <option value="randomize">Randomize</option>
                                 <option value="keep">Keep original</option>
-                                <option value="remove">Remove</option>
+                                <option value="remove" selected>Remove (default)</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
                         </div>
                         <div class="field-option">
                             <label for="paste-location">Location</label>
                             <select id="paste-location" name="location">
-                                <option value="randomize" selected>Randomize (default)</option>
+                                <option value="randomize">Randomize</option>
                                 <option value="keep">Keep original</option>
-                                <option value="remove">Remove</option>
+                                <option value="remove" selected>Remove (default)</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
                         </div>
                         <div class="field-option">
                             <label for="paste-comment">Comment</label>
                             <select id="paste-comment" name="comment">
-                                <option value="randomize" selected>Randomize (default)</option>
+                                <option value="randomize">Randomize</option>
                                 <option value="keep">Keep original</option>
-                                <option value="remove">Remove</option>
+                                <option value="remove" selected>Remove (default)</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
                         </div>
                         <div class="field-option">
                             <label for="paste-contact">Contact</label>
                             <select id="paste-contact" name="contact">
-                                <option value="randomize" selected>Randomize (default)</option>
+                                <option value="randomize">Randomize</option>
                                 <option value="keep">Keep original</option>
-                                <option value="remove">Remove</option>
+                                <option value="remove" selected>Remove (default)</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
                         </div>
                         <div class="field-option">
                             <label for="paste-resources">Resources</label>
                             <select id="paste-resources" name="resources">
-                                <option value="randomize" selected>Randomize (default)</option>
+                                <option value="randomize">Randomize</option>
                                 <option value="keep">Keep original</option>
-                                <option value="remove">Remove</option>
+                                <option value="remove" selected>Remove (default)</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
                         </div>
                         <div class="field-option">
                             <label for="paste-categories">Categories</label>
                             <select id="paste-categories" name="categories">
-                                <option value="randomize" selected>Randomize (default)</option>
+                                <option value="randomize">Randomize</option>
                                 <option value="keep">Keep original</option>
-                                <option value="remove">Remove</option>
+                                <option value="remove" selected>Remove (default)</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
                         </div>
                         <div class="field-option">
                             <label for="paste-attendee">Attendee</label>
                             <select id="paste-attendee" name="attendee">
-                                <option value="randomize" selected>Randomize (default)</option>
+                                <option value="randomize">Randomize</option>
                                 <option value="keep">Keep original</option>
-                                <option value="remove">Remove</option>
+                                <option value="remove" selected>Remove (default)</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
                         </div>
                         <div class="field-option">
                             <label for="paste-organizer">Organizer</label>
                             <select id="paste-organizer" name="organizer">
-                                <option value="randomize" selected>Randomize (default)</option>
+                                <option value="randomize">Randomize</option>
                                 <option value="keep">Keep original</option>
-                                <option value="remove">Remove</option>
+                                <option value="remove" selected>Remove (default)</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
                         </div>
@@ -296,8 +296,8 @@
                         <div class="field-option">
                             <label for="fetch-summary">Summary</label>
                             <select id="fetch-summary" name="summary">
-                                <option value="randomize" selected>Randomize (default)</option>
-                                <option value="keep">Keep original</option>
+                                <option value="randomize">Randomize</option>
+                                <option value="keep" selected>Keep original (default)</option>
                                 <option value="remove">Remove</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
@@ -305,72 +305,72 @@
                         <div class="field-option">
                             <label for="fetch-description">Description</label>
                             <select id="fetch-description" name="description">
-                                <option value="randomize" selected>Randomize (default)</option>
+                                <option value="randomize">Randomize</option>
                                 <option value="keep">Keep original</option>
-                                <option value="remove">Remove</option>
+                                <option value="remove" selected>Remove (default)</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
                         </div>
                         <div class="field-option">
                             <label for="fetch-location">Location</label>
                             <select id="fetch-location" name="location">
-                                <option value="randomize" selected>Randomize (default)</option>
+                                <option value="randomize">Randomize</option>
                                 <option value="keep">Keep original</option>
-                                <option value="remove">Remove</option>
+                                <option value="remove" selected>Remove (default)</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
                         </div>
                         <div class="field-option">
                             <label for="fetch-comment">Comment</label>
                             <select id="fetch-comment" name="comment">
-                                <option value="randomize" selected>Randomize (default)</option>
+                                <option value="randomize">Randomize</option>
                                 <option value="keep">Keep original</option>
-                                <option value="remove">Remove</option>
+                                <option value="remove" selected>Remove (default)</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
                         </div>
                         <div class="field-option">
                             <label for="fetch-contact">Contact</label>
                             <select id="fetch-contact" name="contact">
-                                <option value="randomize" selected>Randomize (default)</option>
+                                <option value="randomize">Randomize</option>
                                 <option value="keep">Keep original</option>
-                                <option value="remove">Remove</option>
+                                <option value="remove" selected>Remove (default)</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
                         </div>
                         <div class="field-option">
                             <label for="fetch-resources">Resources</label>
                             <select id="fetch-resources" name="resources">
-                                <option value="randomize" selected>Randomize (default)</option>
+                                <option value="randomize">Randomize</option>
                                 <option value="keep">Keep original</option>
-                                <option value="remove">Remove</option>
+                                <option value="remove" selected>Remove (default)</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
                         </div>
                         <div class="field-option">
                             <label for="fetch-categories">Categories</label>
                             <select id="fetch-categories" name="categories">
-                                <option value="randomize" selected>Randomize (default)</option>
+                                <option value="randomize">Randomize</option>
                                 <option value="keep">Keep original</option>
-                                <option value="remove">Remove</option>
+                                <option value="remove" selected>Remove (default)</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
                         </div>
                         <div class="field-option">
                             <label for="fetch-attendee">Attendee</label>
                             <select id="fetch-attendee" name="attendee">
-                                <option value="randomize" selected>Randomize (default)</option>
+                                <option value="randomize">Randomize</option>
                                 <option value="keep">Keep original</option>
-                                <option value="remove">Remove</option>
+                                <option value="remove" selected>Remove (default)</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
                         </div>
                         <div class="field-option">
                             <label for="fetch-organizer">Organizer</label>
                             <select id="fetch-organizer" name="organizer">
-                                <option value="randomize" selected>Randomize (default)</option>
+                                <option value="randomize">Randomize</option>
                                 <option value="keep">Keep original</option>
-                                <option value="remove">Remove</option>
+                                <option value="remove" selected>Remove (default)</option>
                                 <option value="replace">Replace with placeholder</option>
                             </select>
                         </div>


### PR DESCRIPTION
Fixes #117.

SUMMARY defaults to keep, personal fields default to remove, UID stays randomized. Library defaults unchanged — tracked separately in #128.