### PR TITLE
fix: pin setup-uv to v8.1.0

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0  # Need full history for version detection
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "0.9.21"
           cache-dependency-glob: "pyproject.toml"


### PR DESCRIPTION
Floating `v8` tag does not exist for `astral-sh/setup-uv` (only `v7` is published as a floating major). Pinning to exact `v8.1.0` to unblock Cloudflare deploys.