### PR TITLE
chore: prepare v0.1.5 changelog section

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,24 @@ Change log
 ..
 .. - Start with a past tense verb, such as "Added", "Fixed", "Removed", "Updated", and other verbs.
 
+0.1.5 (unreleased)
+------------------
+
+.. _v0.1.5-new-features:
+
+New features
+''''''''''''
+
+.. _v0.1.5-minor-changes:
+
+Minor changes
+'''''''''''''
+
+.. _v0.1.5-bug-fixes:
+
+Bug fixes
+'''''''''
+
 0.1.4 (2026-04-20)
 ------------------
 


### PR DESCRIPTION
Adds empty `0.1.5 (unreleased)` section so future PRs have a place to land their changelog entries.