### PR TITLE
docs: add security policy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,7 @@ New features
 
 - Added Dependabot config. See `Issue 78 <https://github.com/pycalendar/icalendar-anonymizer/issues/78>`_.
 - Added ``CODEOWNERS``. See `Issue 28 <https://github.com/pycalendar/icalendar-anonymizer/issues/28>`_.
+- Added ``SECURITY.md``. See `Issue 44 <https://github.com/pycalendar/icalendar-anonymizer/issues/44>`_.
 
 .. _v0.1.5-minor-changes:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+<!--- SPDX-FileCopyrightText: 2025 icalendar-anonymizer contributors -->
+<!--- SPDX-License-Identifier: AGPL-3.0-or-later -->
+
+# Security policy
+
+## Reporting a vulnerability
+
+Report vulnerabilities privately via one of:
+
+- [GitHub Security Advisories](https://github.com/pycalendar/icalendar-anonymizer/security/advisories/new) (preferred)
+- Email: team@pycal.org
+
+Please do not open public issues for security reports.
+
+We ask that you delay public disclosure for at least 90 days after reporting, to give us time to coordinate a fix.
+
+## Supported versions
+
+Security fixes are only applied to the latest release. Upgrade to the latest version to receive security updates.
+
+## Disclosure process
+
+After a report is verified and fixed:
+
+- We publish a GitHub Security Advisory, which is submitted to the CVE List and the [GitHub Advisory Database](https://github.com/advisories).
+- We release a bug-fix version.
+- We announce the fix in the [change log](https://github.com/pycalendar/icalendar-anonymizer/blob/main/CHANGES.rst) and GitHub release notes.
+- We credit the reporter in the advisory (unless they prefer to remain anonymous).


### PR DESCRIPTION
Fixes #44.

Adds SECURITY.md with GitHub Security Advisories as preferred reporting channel and team@pycal.org as email fallback.