### PR TITLE
docs: add examples page with real-world workflows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,7 @@ New features
 - Added Dependabot config. See `Issue 78 <https://github.com/pycalendar/icalendar-anonymizer/issues/78>`_.
 - Added ``CODEOWNERS``. See `Issue 28 <https://github.com/pycalendar/icalendar-anonymizer/issues/28>`_.
 - Added ``SECURITY.md``. See `Issue 44 <https://github.com/pycalendar/icalendar-anonymizer/issues/44>`_.
+- Added :file:`docs/examples.rst` with real-world workflows. See `Issue 59 <https://github.com/pycalendar/icalendar-anonymizer/issues/59>`_.
 
 .. _v0.1.5-minor-changes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,7 @@ New features
 - Added ``SECURITY.md``. See `Issue 44 <https://github.com/pycalendar/icalendar-anonymizer/issues/44>`_.
 - Added ``field_modes`` support to Fernet live-proxy tokens so per-field UI choices are applied on fetch. See `Issue 139 <https://github.com/pycalendar/icalendar-anonymizer/issues/139>`_.
 - Added Open Web Calendar tutorial at :file:`docs/tutorials/open-web-calendar.rst`. See `Issue 93 <https://github.com/pycalendar/icalendar-anonymizer/issues/93>`_.
+- Added :file:`docs/examples.rst` with real-world workflows. See `Issue 59 <https://github.com/pycalendar/icalendar-anonymizer/issues/59>`_.
 
 .. _v0.1.5-minor-changes:
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,0 +1,83 @@
+.. SPDX-FileCopyrightText: 2025 icalendar-anonymizer contributors
+.. SPDX-License-Identifier: AGPL-3.0-or-later
+
+========
+Examples
+========
+
+Complete workflows for common use cases.
+
+Anonymizing a Google Calendar export for a bug report
+=====================================================
+
+Export a calendar from Google Calendar (Settings → Import & export → Export), then run it through the anonymizer before attaching it to a bug report.
+
+.. code-block:: shell
+
+    ican calendar.ics -o anonymized.ics
+
+The output preserves dates, recurrence, and timezone data while stripping names, emails, and personal text. Attach ``anonymized.ics`` to the bug report.
+
+To keep event titles visible, use the ``--summary keep`` flag:
+
+.. code-block:: shell
+
+    ican --summary keep calendar.ics -o anonymized.ics
+
+Reproducible test data with custom salts
+========================================
+
+By default, each run generates a fresh random salt, so the same input produces different output each time. For tests that assert specific values, pass a fixed salt:
+
+.. code-block:: python
+
+    from icalendar import Calendar
+    from icalendar_anonymizer import anonymize
+
+    with open("calendar.ics", "rb") as f:
+        cal = Calendar.from_ical(f.read())
+
+    # Same salt = same hashed output every time
+    anonymized = anonymize(cal, salt=b"test-fixture-salt-0123456789abcdef")
+
+    with open("tests/fixtures/anonymized.ics", "wb") as f:
+        f.write(anonymized.to_ical())
+
+Pin the salt in version control alongside the fixture. Changing the salt invalidates the fixture.
+
+Batch processing multiple calendar files
+========================================
+
+Anonymize every ``.ics`` file in a directory, writing results to a sibling directory:
+
+.. code-block:: python
+
+    from pathlib import Path
+    from icalendar import Calendar
+    from icalendar_anonymizer import anonymize
+
+    source = Path("calendars")
+    target = Path("anonymized")
+    target.mkdir(exist_ok=True)
+
+    for ics_path in source.glob("*.ics"):
+        cal = Calendar.from_ical(ics_path.read_bytes())
+        anonymized = anonymize(cal)
+        (target / ics_path.name).write_bytes(anonymized.to_ical())
+
+For a shell-only pipeline:
+
+.. code-block:: shell
+
+    for f in calendars/*.ics; do
+        ican "$f" -o "anonymized/$(basename "$f")"
+    done
+
+Debugging recurrence and timezone issues
+========================================
+
+When reporting a bug in recurrence expansion or timezone handling, the technical properties (``RRULE``, ``RDATE``, ``EXDATE``, ``DTSTART``, ``TZID``, ``VTIMEZONE``) are exactly what maintainers need. The anonymizer preserves all of these by default.
+
+If the bug requires a specific ``SUMMARY`` or ``CATEGORIES`` value to reproduce (for example, a parser triggered by a specific string), use ``--summary keep`` or ``--categories keep`` and confirm the preserved fields don't contain personal data before sharing.
+
+To get reproducible hashed ``UID`` values so maintainers can match events across runs, use the Python API with a fixed salt (see the "Reproducible test data" example above).

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -5,18 +5,20 @@
 Examples
 ========
 
-Complete workflows for common use cases.
+This chapter provides example workflows for common use cases.
 
-Anonymizing a Google Calendar export for a bug report
-=====================================================
+Anonymize a Google Calendar export for a bug report
+===================================================
 
-Export a calendar from Google Calendar (Settings → Import & export → Export), then run it through the anonymizer before attaching it to a bug report.
+From your Google Calendar, export it to an iCalendar file via :menuselection:`Settings --> Import & export --> Export`, then click the :guilabel:`Export` button.
+Before attaching it to a bug report, run the exported file through the anonymizer with the following command.
 
 .. code-block:: shell
 
     ican calendar.ics -o anonymized.ics
 
-The output preserves dates, recurrence, and timezone data while stripping names, emails, and personal text. Attach ``anonymized.ics`` to the bug report.
+The output preserves dates, recurrence, and timezone data while stripping names, emails, and personal text.
+Attach :file:`anonymized.ics` to the bug report.
 
 To keep event titles visible, use the ``--summary keep`` flag:
 
@@ -24,10 +26,13 @@ To keep event titles visible, use the ``--summary keep`` flag:
 
     ican --summary keep calendar.ics -o anonymized.ics
 
+.. _reproducible-test-data-with-custom-salts:
+
 Reproducible test data with custom salts
 ========================================
 
-By default, each run generates a fresh random salt, so the same input produces different output each time. For tests that assert specific values, pass a fixed salt:
+By default, each run generates a fresh random salt, so the same input produces different output each time.
+For tests that assert specific values, pass a fixed salt:
 
 .. code-block:: python
 
@@ -43,10 +48,11 @@ By default, each run generates a fresh random salt, so the same input produces d
     with open("tests/fixtures/anonymized.ics", "wb") as f:
         f.write(anonymized.to_ical())
 
-Pin the salt in version control alongside the fixture. Changing the salt invalidates the fixture.
+Pin the salt in version control alongside the fixture.
+Changing the salt invalidates the fixture.
 
-Batch processing multiple calendar files
-========================================
+Batch process multiple calendar files
+=====================================
 
 Anonymize every ``.ics`` file in a directory, writing results to a sibling directory:
 
@@ -73,11 +79,12 @@ For a shell-only pipeline:
         ican "$f" -o "anonymized/$(basename "$f")"
     done
 
-Debugging recurrence and timezone issues
-========================================
+Debug recurrence and timezone issues
+====================================
 
-When reporting a bug in recurrence expansion or timezone handling, the technical properties (``RRULE``, ``RDATE``, ``EXDATE``, ``DTSTART``, ``TZID``, ``VTIMEZONE``) are exactly what maintainers need. The anonymizer preserves all of these by default.
+When reporting a bug in recurrence expansion or timezone handling, the technical properties (``RRULE``, ``RDATE``, ``EXDATE``, ``DTSTART``, ``TZID``, and ``VTIMEZONE``) are exactly what maintainers need.
+The anonymizer preserves all of these by default.
 
 If the bug requires a specific ``SUMMARY`` or ``CATEGORIES`` value to reproduce (for example, a parser triggered by a specific string), use ``--summary keep`` or ``--categories keep`` and confirm the preserved fields don't contain personal data before sharing.
 
-To get reproducible hashed ``UID`` values so maintainers can match events across runs, use the Python API with a fixed salt (see the "Reproducible test data" example above).
+To get reproducible hashed ``UID`` values so maintainers can match events across runs, use the Python API with a fixed salt as described in the above section, :ref:`reproducible-test-data-with-custom-salts`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,6 +52,12 @@ Strip personal data from iCalendar files while preserving technical properties f
 
         Publish an anonymized calendar with Open Web Calendar
 
+    .. grid-item-card:: 📖 Examples
+        :link: examples
+        :link-type: doc
+
+        Practical workflows for common scenarios
+
     .. grid-item-card:: 🤝 Contributing
         :link: contributing
         :link-type: doc
@@ -112,6 +118,7 @@ Documentation
     usage/web-service
     usage/self-hosting
     tutorials/open-web-calendar
+    examples
     api/index
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,12 @@ Strip personal data from iCalendar files while preserving technical properties f
 
         Function signatures and module documentation
 
+    .. grid-item-card:: 📖 Examples
+        :link: examples
+        :link-type: doc
+
+        Practical workflows for common scenarios
+
     .. grid-item-card:: 🤝 Contributing
         :link: contributing
         :link-type: doc
@@ -105,6 +111,7 @@ Documentation
     usage/cli
     usage/web-service
     usage/self-hosting
+    examples
     api/index
 
 .. toctree::


### PR DESCRIPTION
Fixes #59.

Adds `docs/examples.rst` with four workflows: Google Calendar bug reports, reproducible test data with custom salts, batch processing, and recurrence/timezone debugging.